### PR TITLE
feat(node): add KGW cookie session helpers on NodeKwil

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idos-network/kwil-js",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist-esm/index.mjs",

--- a/src/client/node/nodeKwil.ts
+++ b/src/client/node/nodeKwil.ts
@@ -7,7 +7,7 @@ import { GenericResponse } from '../../core/resreq';
 import { Kwil } from '../kwil';
 
 export class NodeKwil extends Kwil<EnvironmentType.NODE> {
-  private tempCookie: string | undefined;
+  private tempCookie?: { previous: string | undefined };
 
   constructor(opts: Config) {
     super(opts);
@@ -37,7 +37,7 @@ export class NodeKwil extends Kwil<EnvironmentType.NODE> {
       // when manually passing cookies, the user is expected to pass the cookie for each request
       // if a user does not pass a cookie for a subsequent request, the cookie will be reset to the original cookie
       if (this.tempCookie) {
-        this.resetTempCookie(this.tempCookie);
+        this.resetTempCookie();
       }
     };
 
@@ -50,22 +50,44 @@ export class NodeKwil extends Kwil<EnvironmentType.NODE> {
   }
 
   /**
+   * Returns the KGW session cookie currently attached to Node requests.
+   */
+  public getKgwCookie(): string | undefined {
+    return this.cookie;
+  }
+
+  /**
+   * Authenticates with KGW, stores the returned session cookie, and returns it.
+   */
+  public async authenticateKGWAndSetCookie(signer: KwilSigner): Promise<string> {
+    const res = await this.auth.authenticateKGW(signer);
+    const cookie = res.data?.cookie;
+
+    if (!cookie) {
+      throw new Error('No cookie received from gateway. An error occurred with authentication.');
+    }
+
+    this.cookie = cookie;
+    return cookie;
+  }
+
+  /**
    * set the temp cookie to reset it after the call
    *
    * @param {string} cookie - The temporary cookie
    * @returns the temporary cookie to handle for Node
    */
   private setTemporaryCookie(cookie: string): void {
-    this.tempCookie = this.cookie;
+    this.tempCookie = { previous: this.cookie };
     this.cookie = cookie;
   }
 
   /**
    * Resets the temporary cookie
    *
-   * @param {string} tempCookie - the temporary cookie to be reset
    */
-  private resetTempCookie(tempCookie: string): void {
-    this.cookie = tempCookie;
+  private resetTempCookie(): void {
+    this.cookie = this.tempCookie?.previous;
+    this.tempCookie = undefined;
   }
 }

--- a/tests/unitTests/client/kwil_client.test.ts
+++ b/tests/unitTests/client/kwil_client.test.ts
@@ -1,4 +1,4 @@
-import { getMock, postMock } from "../api_client/api-utils";
+import { getMock, mockedAxios, postMock } from "../api_client/api-utils";
 import { Msg } from "../../../src/core/message";
 import { stringToBytes, stringToHex } from "../../../src/utils/serial";
 import { bytesToBase64 } from "../../../src/utils/base64";
@@ -21,6 +21,7 @@ describe('Kwil', () => {
 
     beforeEach(() => {
         kwil = new TestKwil();
+        mockedAxios.create.mockClear();
         getMock.mockReset();
         postMock.mockReset();
     });
@@ -62,6 +63,79 @@ describe('Kwil', () => {
             expect(result.data?.nonce).toBe(mockAccount.nonce);
         })
     })
+
+    describe('KGW cookie session', () => {
+        it('should expose the current KGW cookie', () => {
+            expect(kwil.getKgwCookie()).toBeUndefined();
+        });
+
+        it('should authenticate, store the returned KGW cookie, and attach it to later Node requests', async () => {
+            const cookie = 'kgw_session=fresh; Path=/';
+            const signer = new KwilSigner(
+                async () => new Uint8Array([1, 2, 3]),
+                new Uint8Array([4, 5, 6]),
+                'ed25519'
+            );
+
+            postMock
+                .mockResolvedValueOnce({
+                    status: 200,
+                    data: {
+                        jsonrpc: '2.0',
+                        id: 1,
+                        result: {
+                            nonce: '123456',
+                            statement: '',
+                            issue_at: '2026-05-15T14:30:00Z',
+                            expiration_time: '2026-05-15T14:35:00Z',
+                            chain_id: 'doesnt matter',
+                            domain: 'doesnt matter',
+                            version: '1',
+                            uri: 'doesnt matter/auth',
+                        },
+                    },
+                })
+                .mockResolvedValueOnce({
+                    status: 200,
+                    headers: {
+                        'set-cookie': [cookie],
+                    },
+                    data: {
+                        jsonrpc: '2.0',
+                        id: 2,
+                        result: {
+                            result: 'authenticated',
+                        },
+                    },
+                })
+                .mockResolvedValueOnce({
+                    status: 200,
+                    data: {
+                        jsonrpc: '2.0',
+                        id: 3,
+                        result: {
+                            id: {
+                                identifier: address,
+                                key_type: 'secp256k1',
+                            },
+                            balance: 'mockBalance',
+                            nonce: 123,
+                        },
+                    },
+                });
+
+            await expect(kwil.authenticateKGWAndSetCookie(signer)).resolves.toBe(cookie);
+            expect(kwil.getKgwCookie()).toBe(cookie);
+
+            await kwil.getAccount(address);
+
+            const createCalls = mockedAxios.create.mock.calls;
+            const latestConfig = createCalls[createCalls.length - 1][0];
+            const latestHeaders = latestConfig?.headers as Record<string, string> | undefined;
+
+            expect(latestHeaders?.Cookie).toBe(cookie);
+        });
+    });
 
 
 


### PR DESCRIPTION
## Summary

- Add `NodeKwil.getKgwCookie()` to read the KGW session cookie used on Node requests.
- Add `NodeKwil.authenticateKGWAndSetCookie(signer)` to run KGW auth, persist the returned cookie on the client, and return it for callers that need it explicitly.
- Fix temporary per-call cookie handling: store the previous cookie in `{ previous }` and restore it after `call()` instead of conflating the saved value with the active cookie string.
- Add unit tests covering cookie exposure, authenticate-and-store flow, and cookie attachment on subsequent requests.
- Bump package version to `0.1.4`.

## Motivation

Node clients need a first-class way to authenticate with KGW once, keep the session cookie on `NodeKwil`, and reuse it on later Node calls without passing `actionBody.cookie` on every request. The temp-cookie path for per-call overrides also needed a correct restore when no cookie was set before the override.

## API changes

| Method | Description |
|--------|-------------|
| `getKgwCookie(): string \| undefined` | Current KGW session cookie on the client |
| `authenticateKGWAndSetCookie(signer): Promise<string>` | Authenticate via KGW, set `this.cookie`, return the cookie; throws if none is returned |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new capabilities for managing gateway session cookies, including retrieval of current session state and direct authentication with the gateway for improved session control.

* **Refactor**
  * Enhanced cookie state tracking mechanisms for more reliable temporary session handling.

* **Chores**
  * Version bumped to 0.1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->