### PR TITLE
fix(call): expose CallResult.error from call() responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [Unreleased]
+
+### Bug Fixes
+
+* expose `CallResult.error` from `call()` responses so action-level errors are distinguishable from empty result sets
+
 ### [0.9.5](https://github.com/trufnetwork/kwil-js/compare/v0.9.3...v0.9.5) (2025-04-01)
 
 

--- a/src/api_client/client.ts
+++ b/src/api_client/client.ts
@@ -307,12 +307,11 @@ export default class Client extends Api {
       return errorResponse;
     }
 
-    return checkRes(res, (r) => {
-      return {
-        result: this.parseQueryResponse(r.result.query_result),
-        logs: r.result.logs
-      }
-    });
+    return checkRes(res, (r) => ({
+      result: this.parseQueryResponse(r.result.query_result),
+      logs: r.result.logs,
+      error: r.result.error ?? undefined,
+    }));
   }
 
   private buildJsonRpcRequest<T>(method: JSONRPCMethod, params: T): JsonRPCRequest<T> {

--- a/src/client/node/nodeKwil.ts
+++ b/src/client/node/nodeKwil.ts
@@ -19,7 +19,7 @@ export class NodeKwil extends Kwil<EnvironmentType.NODE> {
    *
    * @param {CallBodyNode} actionBody - The body of the action to send. This should use the `CallBody` interface.
    * @param {KwilSigner} kwilSigner (optional) - KwilSigner should be passed if the action requires authentication OR if the action uses a `@caller` contextual variable. If `@caller` is used and authentication is not required, the user will not be prompted to authenticate; however, the user's identifier will be passed as the sender.
-   * @returns An Object[] with the result of the action
+   * @returns A `MsgReceipt` with `result`, optional `logs`, and optional `error`. `data.error` is set when the action executed but returned an application error via `error(...)` in Kuneiform. `data.result` may be empty in both error and "no rows" cases; check `data.error` first to distinguish.
    */
   public async call<T extends Object>(
     actionBody: CallBodyNode,

--- a/src/client/web/webKwil.ts
+++ b/src/client/web/webKwil.ts
@@ -17,7 +17,7 @@ export class WebKwil extends Kwil<EnvironmentType.BROWSER> {
    *
    * @param {CallBody} actionBody - The body of the action to send. This should use the `CallBody` interface.
    * @param {KwilSigner} kwilSigner (optional) - KwilSigner should be passed if the action requires authentication OR if the action uses a `@caller` contextual variable. If `@caller` is used and authentication is not required, the user will not be prompted to authenticate; however, the user's identifier will be passed as the sender.
-   * @returns An Object[] with the result of the action or a MsgReceipt
+   * @returns A `MsgReceipt` with `result`, optional `logs`, and optional `error`. `data.error` is set when the action executed but returned an application error via `error(...)` in Kuneiform. `data.result` may be empty in both error and "no rows" cases; check `data.error` first to distinguish.
    */
   public async call<T extends Object>(
     actionBody: CallBody,

--- a/src/core/message.ts
+++ b/src/core/message.ts
@@ -9,6 +9,7 @@ import { AnySignatureType, Signature, SignatureType } from './signature';
 export interface MsgReceipt<T extends object> {
   get result(): Nillable<T[]>;
   logs?: string;
+  error?: string;
 }
 
 /**

--- a/tests/unitTests/api_client/client.test.ts
+++ b/tests/unitTests/api_client/client.test.ts
@@ -1,7 +1,7 @@
 import { postMock } from './api-utils';
 import Client from '../../../src/api_client/client';
 import { Transaction, Txn } from '../../../src/core/tx';
-import { CallClientResponse, Message } from '../../../src/core/message';
+import { CallClientResponse, Message, Msg } from '../../../src/core/message';
 import { BytesEncodingStatus } from '../../../src/core/enums';
 import { stringToBytes } from '../../../dist/utils/serial';
 import { bytesToBase64 } from '../../../src/utils/base64';
@@ -137,6 +137,99 @@ describe('Client', () => {
         it('should throw an error when broadcasting an unsigned transaction', async () => {
             const tx = Txn.create<BytesEncodingStatus.BASE64_ENCODED>(() => {}); // Assuming this transaction is unsigned by default
             await expect(client.broadcast(tx)).rejects.toThrow('Tx must be signed before broadcasting.');
+        });
+    });
+
+    describe('call', () => {
+        const callMessage = Msg.create((msg) => {
+            msg.body.payload = 'payload';
+        });
+
+        const emptyQueryResult = {
+            column_names: [] as string[],
+            column_types: [] as { name: string; is_array: boolean }[],
+            values: [] as unknown[],
+        };
+
+        it('should expose action-level error when CallResult.error is set', async () => {
+            postMock.mockResolvedValue({
+                status: 200,
+                data: {
+                    jsonrpc: '2.0',
+                    id: 1,
+                    result: {
+                        query_result: emptyQueryResult,
+                        logs: 'some logs',
+                        error: 'Unauthorized gateway',
+                    },
+                },
+            });
+
+            const result = await client.call(callMessage);
+
+            expect(result.status).toBe(200);
+            expect(result.data?.error).toBe('Unauthorized gateway');
+            expect(result.data?.result).toEqual([]);
+            expect(result.data?.logs).toBe('some logs');
+        });
+
+        it('should return undefined error when CallResult.error is null', async () => {
+            postMock.mockResolvedValue({
+                status: 200,
+                data: {
+                    jsonrpc: '2.0',
+                    id: 1,
+                    result: {
+                        query_result: emptyQueryResult,
+                        error: null,
+                    },
+                },
+            });
+
+            const result = await client.call(callMessage);
+
+            expect(result.data?.error).toBeUndefined();
+            expect(result.data?.result).toEqual([]);
+        });
+
+        it('should return undefined error when CallResult.error is absent', async () => {
+            postMock.mockResolvedValue({
+                status: 200,
+                data: {
+                    jsonrpc: '2.0',
+                    id: 1,
+                    result: {
+                        query_result: emptyQueryResult,
+                    },
+                },
+            });
+
+            const result = await client.call(callMessage);
+
+            expect(result.data?.error).toBeUndefined();
+            expect(result.data?.result).toEqual([]);
+        });
+
+        it('should parse rows when CallResult.error is absent', async () => {
+            postMock.mockResolvedValue({
+                status: 200,
+                data: {
+                    jsonrpc: '2.0',
+                    id: 1,
+                    result: {
+                        query_result: {
+                            column_names: ['title'],
+                            column_types: [{ name: 'text', is_array: false }],
+                            values: [['row1']],
+                        },
+                    },
+                },
+            });
+
+            const result = await client.call(callMessage);
+
+            expect(result.data?.error).toBeUndefined();
+            expect(result.data?.result).toEqual([{ title: 'row1' }]);
         });
     });
 });


### PR DESCRIPTION
## Summary

- Map Kwil's action-level `CallResult.error` through `callClient()` so `call()` returns it on `res.data.error`
- Extend `MsgReceipt` with optional `error?: string` and document how to distinguish action errors from empty result sets
- Add unit tests covering error, null/absent error, and successful row parsing

## Problem

When a view action calls `error('...')` in Kuneiform, Kwil returns HTTP 200 with `result.error` set and an empty `query_result`. `callClient()` previously only mapped `query_result` and `logs`, so consumers saw `data.result === []` for both legitimate empty results and action errors.

## Solution

Pass through `r.result.error ?? undefined` in `callClient()` and expose it on `MsgReceipt`. This is additive only — existing callers that read `res.data?.result` continue to work unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The `call()` method now returns error information in its responses, allowing you to distinguish between actual application-level errors and empty result sets. Check the error field first when evaluating call results.

* **Documentation**
  * Updated call method documentation to clarify the new error field structure and proper error-checking patterns for responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->